### PR TITLE
Update agents and tasks configuration for MACD trading system

### DIFF
--- a/.github/workflows/hourly_run.yml
+++ b/.github/workflows/hourly_run.yml
@@ -2,7 +2,7 @@ name: Hourly Script Execution
 
 on:
   schedule:
-    - cron: "0 * * * 1-5"
+    - cron: "0 10-18 * * 1-5"
   push:
     branches:
       - master

--- a/src/macd_trader/config/agents.yaml
+++ b/src/macd_trader/config/agents.yaml
@@ -8,7 +8,7 @@ trading_strategist:
   role: "MACD交易策略专家"
   goal: "分析{stock_ticker}的MACD技术指标，识别金叉（MACD线上穿信号线）和死叉（MACD线下穿信号线）信号，结合股价趋势和柱状图变化判断买入或卖出时机。"
   backstory: "你是一位专注于MACD指标的量化分析师，精通通过分析MACD线（快线）、信号线（慢线）和柱状图之间的关系来识别市场趋势。你善于发现MACD交叉点所产生的交易机会，并能根据柱状图的形态变化判断信号的强弱和可靠性。"
-  allow_delegation: true
+  allow_delegation: false
 
 investment_advisor:
   role: "投资策略顾问"

--- a/src/macd_trader/config/tasks.yaml
+++ b/src/macd_trader/config/tasks.yaml
@@ -6,7 +6,7 @@ fetch_data_task:
     3. 将获取的数据整理成标准格式，包含最新交易时间、收盘价、MACD值及信号线数值
     4. 返回包含最新时间戳、收盘价、MACD值和MACD信号线值的列表
   goal: 获取{stock_ticker}的最新MACD数据。
-  expected_output: 包含最新时间戳、收盘价、MACD值和MACD信号线值的列表。
+  expected_output: 有效的分日数据列表，包含日期、收盘价、MACD线值、信号线和MACD柱状图值。
 
 analyze_macd_task:
   description: >
@@ -24,7 +24,7 @@ generate_advice_task:
   description: >
     任务描述：
     1. 整合{stock_ticker}的实时股价数据和MACD技术分析结果（包括买入/卖出/持有信号）
-    2. 生成投资建议报告，标题格式为："{stock_ticker} [信号]"，例如："股票名称 [买入]"
+    2. 生成中文投资建议报告，标题格式为："{stock_ticker} [信号]"，例如："股票名称 [买入]"
     3. 报告内容应包含以下关键部分：
        a. 最新市场数据：当前股价和关键MACD指标值
        b. 市场信号分析：详细解释为何推荐买入/卖出/持有的技术依据

--- a/src/macd_trader/tools/longbridge_tools.py
+++ b/src/macd_trader/tools/longbridge_tools.py
@@ -98,7 +98,7 @@ class LongBridgeMACDTool(BaseTool):
             logging.error(f"Error calculating MACD for {ticker}: {e}")
             return f"Error calculating MACD for {ticker}: {e}"
 
-    def _run(self, ticker: str, mode: str = "macd") -> str:
+    def _run(self, ticker: str, mode: str = "macd") -> tuple[list[dict], str]:
         """
         Runs the specified tool function (get_macd).
         """


### PR DESCRIPTION
- Set allow_delegation to false for trading strategist in agents.yaml
- Refine expected_output description in fetch_data_task for clarity in tasks.yaml
- Specify generation of Chinese investment advice report in generate_advice_task in tasks.yaml
- Update return type annotation for _run method in LongBridgeMACDTool class